### PR TITLE
Update documentation URLs, license

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,5 +25,5 @@ Even better: You could submit a pull request with a fix / new feature!
    developers, or if you do not have permission to do that, you may request
    the second reviewer to merge it for you.
 
-[github]: https://github.com/lfarkas/addon-netbird/issues
-[prs]: https://github.com/lfarkas/addon-netbird/pulls
+[github]: https://github.com/netbirdio/addon-netbird/issues
+[prs]: https://github.com/netbirdio/addon-netbird/pulls

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Levente Farkas (https://github.com/lfarkas)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023 Levente Farkas
+Copyright (c) 2023 Wiretrustee UG (haftungsbeschränkt) & AUTHORS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Thank you for being involved! :heart_eyes:
 
 MIT License
 
-Copyright (c) 2023-2023 Levente Farkas
+Copyright (c) 2023 Wiretrustee UG (haftungsbeschränkt) & AUTHORS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/netbird/DOCS.md
+++ b/netbird/DOCS.md
@@ -11,7 +11,7 @@ NetBird uses NAT traversal techniques to automatically create an overlay peer-to
 The installation of this add-on is pretty straightforward and not different in
 comparison to installing any other Home Assistant add-on.
 
-1. Add my Hass.io add-ons repository (**<https://github.com/lfarkas/addon-netbird>**) to your Hass.io instance.
+1. Add my Hass.io add-ons repository (**<https://github.com/netbirdio/addon-netbird>**) to your Hass.io instance.
 1. Click the Home Assistant My button below to open the add-on on your Home
    Assistant instance.
 
@@ -152,3 +152,5 @@ SOFTWARE.
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/addon-netbird/releases
 [semver]: http://semver.org/spec/v2.0.0.html
+[netbird]: https://github.com/netbirdio/netbird
+[lfarkas]: https://github.com/lfarkas

--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -3,7 +3,7 @@ name: NetBird
 version: v0.24.3
 slug: netbird
 description: Connect your devices into a single secure private WireGuard®-based mesh network.
-url: https://github.com/lfarkas/addon-netbird
+url: https://github.com/netbirdio/addon-netbird
 codenotary: lfarkas@lfarkas.org
 startup: services
 panel_icon: mdi:vpn

--- a/netbird/translations/en.yaml
+++ b/netbird/translations/en.yaml
@@ -14,7 +14,7 @@ configuration:
   management_url:
     name: Management URL
     description: >-
-      Management Service URL [http|https]://[host]:[port] (default "https://api.wiretrustee.com:33073")
+      Management Service URL [http|https]://[host]:[port] (default "https://api.netbird.io:443")
 
       The client will use this URL to communicate with your NetBird instance api.
   setup_key:

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "NetBird Home Assistant Add-ons",
-  "url": "https://github.com/lfarkas/addon-netbird",
+  "url": "https://github.com/netbirdio/addon-netbird",
   "maintainer": "Levente Farkas <lfarkas@lfarkas.org>"
 }


### PR DESCRIPTION
# Proposed Changes

Update documentation URLs, license after moving project to the netbirdio organization

## Related Issues

https://github.com/netbirdio/netbird/issues/884

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
