### PR TITLE
Change working directory in line home-assistant guidelines

### DIFF
--- a/netbird/DOCS.md
+++ b/netbird/DOCS.md
@@ -26,7 +26,7 @@ comparison to installing any other Home Assistant add-on.
 
 ## Configuration
 
-You'll see the config file at `/config/netbird/config.json` after first boot.
+You'll see the config file at `/addon_config/*_netbird/config.json` after first boot.
 
 ### Option: `log_level`
 

--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -14,7 +14,7 @@ arch:
   - armhf
   - armv7
   - i386
-host_network: false
+host_network: true
 host_dbus: true
 privileged:
   - SYS_ADMIN

--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -23,7 +23,7 @@ privileged:
   - NET_RAW
   - BPF
 map:
-  - config:rw
+  - addon_config:rw
 options:
   admin_url: ""
   management_url: ""

--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -14,7 +14,7 @@ arch:
   - armhf
   - armv7
   - i386
-host_network: true
+host_network: false
 host_dbus: true
 privileged:
   - SYS_ADMIN

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -8,8 +8,7 @@ declare -a options
 declare name
 declare value
 
-touch config/111
-touch /config/222
+
 # Get the options configured in HASS GUI
 readonly CONFIG_PATH=config/config.json
 

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -9,7 +9,7 @@ declare name
 declare value
 
 # Get the options configured in HASS GUI
-readonly CONFIG_PATH=config.json
+readonly CONFIG_PATH=/config/config.json
 
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -9,7 +9,7 @@ declare name
 declare value
 
 # Get the options configured in HASS GUI
-readonly CONFIG_PATH=/config/netbird/config.json
+readonly CONFIG_PATH=/config.json
 
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -10,7 +10,7 @@ declare value
 
 
 # Get the options configured in HASS GUI
-readonly CONFIG_PATH=addons_config/config.json
+readonly CONFIG_PATH=/config/config.json
 
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -9,7 +9,7 @@ declare name
 declare value
 
 # Get the options configured in HASS GUI
-readonly CONFIG_PATH=/config.json
+readonly CONFIG_PATH=/config/config.json
 
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -8,8 +8,10 @@ declare -a options
 declare name
 declare value
 
+touch config/111
+touch /config/222
 # Get the options configured in HASS GUI
-readonly CONFIG_PATH=/config/config.json
+readonly CONFIG_PATH=config/config.json
 
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -10,7 +10,7 @@ declare value
 
 
 # Get the options configured in HASS GUI
-readonly CONFIG_PATH=config/config.json
+readonly CONFIG_PATH=addons_config/config.json
 
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -9,7 +9,7 @@ declare name
 declare value
 
 # Get the options configured in HASS GUI
-readonly CONFIG_PATH=/config/config.json
+readonly CONFIG_PATH=config.json
 
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"


### PR DESCRIPTION
# Proposed Changes

move the configuration directory out of the main home assistant config directory, to the addons_config as intended for external addons.
<img width="314" alt="image" src="https://github.com/user-attachments/assets/da1ef47b-5499-4805-887a-65ff1d1dec2e">

> (Describe the changes and rationale behind them)

Home Assistant house-keeping

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

none
