### PR TITLE
Group NetBird version updates into single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,15 @@
       "automerge": true
     },
     {
+      "groupName": "NetBird",
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchDepNames": [
+        "netbirdio/netbird"
+      ]
+    },
+    {
       "matchDatasources": [
         "github-releases"
       ],


### PR DESCRIPTION
## Summary
- Add `groupName` to Renovate config so updates to both Dockerfile and config.yaml are combined into one PR instead of two separate PRs

## Test plan
- [ ] Wait for next NetBird release and verify Renovate creates a single PR updating both files

🤖 Generated with [Claude Code](https://claude.ai/code)