### PR TITLE
Fix duplicate Renovate PRs for NetBird updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -66,6 +66,15 @@
       "automerge": true
     },
     {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "netbirdio/netbird"
+      ],
+      "enabled": false
+    },
+    {
       "groupName": "Add-on base image",
       "matchDatasources": [
         "docker"


### PR DESCRIPTION
## Summary
- Disable docker datasource for netbirdio/netbird in Renovate config
- Prevents duplicate PRs by stopping Renovate's built-in Dockerfile manager from detecting netbirdio/netbird as a Docker image
- Only the custom github-releases manager will now handle NetBird updates, creating a single grouped PR for both Dockerfile and config.yaml changes

## Test plan
- [ ] Wait for next NetBird release and verify only one PR is created
- [ ] Verify the single PR updates both `netbird/Dockerfile` and `netbird/config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)