### PR TITLE
fix: add iptables via xtables-nft-multi to enable routing on HAOS

### DIFF
--- a/netbird/Dockerfile
+++ b/netbird/Dockerfile
@@ -5,7 +5,11 @@ FROM netbirdio/netbird:0.67.3 as netbird-container
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
-RUN apk add --no-cache nftables=1.1.5-r2
+RUN apk add --no-cache \
+    iptables=1.8.11-r1 \
+    nftables=1.1.5-r2 \
+    && ln -sf /sbin/xtables-nft-multi /sbin/ip6tables \
+    && ln -sf /sbin/xtables-nft-multi /sbin/iptables
 
 # Copy root filesystem
 COPY rootfs /


### PR DESCRIPTION
# Proposed Changes
NetBird uses both nftables and iptables Go libraries internally for firewall and routing management. On HAOS the iptables package is absent from the container, causing NetBird's iptables-based operations (FORWARD rules, NAT) to fail silently when configured as a routing peer or exit node.

Adding iptables backed by xtables-nft-multi provides the iptables interface NetBird requires while routing its rules through the nftables backend that HAOS uses. The existing nftables package is kept alongside.

## Related Issues

Fixes [#172](https://github.com/netbirdio/addon-netbird/issues/172)

---
> Disclaimer: Claude was used to implement the fix.