### PR TITLE
fix: update hostname regex to support full domain names (FQDNs)

### DIFF
--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -33,7 +33,7 @@ schema:
   admin_url: url?
   management_url: url?
   setup_key: str?
-  hostname: match(^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$)?
+  hostname: match(^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$)?
   rosenpass: bool
   rosenpass_permissive: bool
   env_vars:


### PR DESCRIPTION
The previous regex only validated single hostname labels and rejected domains like homeassistant.tld. This update allows full domain names while maintaining validation of each label:

- Each label must start and end with alphanumeric characters
- Labels can contain hyphens in the middle
- Multiple labels separated by dots are now allowed

Examples that now match:
- homeassistant
- ha-device
- homeassistant.tld
- device.example.com

Examples that still don't match (as expected):
- -invalid (starts with hyphen)
- invalid- (ends with hyphen)
- .invalid (starts with dot)

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hostname validation to support fully qualified hostnames with multiple dot-separated domain labels.
  * Kept hostname configuration optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->