### PR TITLE
fix: correct stale app.netbird.io management URL (#401)

### DIFF
--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -33,9 +33,7 @@ log_level="$(bashio::config 'log_level')"
 # the user has not set their own management_url, leaving self-hosted setups
 # untouched; NetBird then rewrites and persists the corrected URL on startup.
 if [ "${management_url}" = "" ] && [ -f "${CONFIG_PATH}" ]; then
-    current_mgmt_url="$(jq -r '.ManagementURL // empty' "${CONFIG_PATH}" 2>/dev/null)"
-    current_mgmt_host="${current_mgmt_url#*://}"
-    current_mgmt_host="${current_mgmt_host%%/*}"
+    current_mgmt_host="$(jq -r '.ManagementURL.Host // empty' "${CONFIG_PATH}" 2>/dev/null)"
     if [ "${current_mgmt_host%%:*}" = "app.netbird.io" ]; then
         bashio::log.warning "Persisted Management URL points at app.netbird.io (dashboard); correcting to https://api.netbird.io"
         management_url="https://api.netbird.io"

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -23,6 +23,23 @@ rosenpass="$(bashio::config 'rosenpass')"
 rosenpass_permissive="$(bashio::config 'rosenpass_permissive')"
 log_level="$(bashio::config 'log_level')"
 
+# Self-heal a stale NetBird Cloud management URL (see issue #401).
+# Older installs persisted https://app.netbird.io as the Management URL in
+# config.json. app.netbird.io only serves the web dashboard and does not
+# negotiate the HTTP/2 ALPN that the management gRPC service requires, so the
+# client fails with "missing selected ALPN property" and never connects.
+# NetBird's built-in auto-migration ignores this host, so correct it here by
+# pointing the client at the real cloud management endpoint. Only applied when
+# the user has not set their own management_url, leaving self-hosted setups
+# untouched; NetBird then rewrites and persists the corrected URL on startup.
+if [ "${management_url}" = "" ] && [ -f "${CONFIG_PATH}" ]; then
+    current_mgmt_host="$(jq -r '.ManagementURL.Host // empty' "${CONFIG_PATH}" 2>/dev/null)"
+    if [ "${current_mgmt_host%%:*}" = "app.netbird.io" ]; then
+        bashio::log.warning "Persisted Management URL points at app.netbird.io (dashboard); correcting to https://api.netbird.io"
+        management_url="https://api.netbird.io"
+    fi
+fi
+
 options+=(--foreground-mode)
 options+=(--config "${CONFIG_PATH}")
 options+=(--log-file console)

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -33,7 +33,9 @@ log_level="$(bashio::config 'log_level')"
 # the user has not set their own management_url, leaving self-hosted setups
 # untouched; NetBird then rewrites and persists the corrected URL on startup.
 if [ "${management_url}" = "" ] && [ -f "${CONFIG_PATH}" ]; then
-    current_mgmt_host="$(jq -r '.ManagementURL.Host // empty' "${CONFIG_PATH}" 2>/dev/null)"
+    current_mgmt_url="$(jq -r '.ManagementURL // empty' "${CONFIG_PATH}" 2>/dev/null)"
+    current_mgmt_host="${current_mgmt_url#*://}"
+    current_mgmt_host="${current_mgmt_host%%/*}"
     if [ "${current_mgmt_host%%:*}" = "app.netbird.io" ]; then
         bashio::log.warning "Persisted Management URL points at app.netbird.io (dashboard); correcting to https://api.netbird.io"
         management_url="https://api.netbird.io"


### PR DESCRIPTION
## Summary

Fixes #401. Affected NetBird Cloud users fail to connect with a gRPC TLS error:
`authentication handshake failed: credentials: cannot check peer: missing selected ALPN property`.

Root cause: the client dials `app.netbird.io:443` (the web dashboard) for the
Management gRPC service instead of `api.netbird.io:443` (the management API).
`app.netbird.io` is fronted by a proxy that terminates TLS for the browser UI
without negotiating the HTTP/2 `h2` ALPN that gRPC-go >= 1.67 enforces, so the
handshake aborts. The wrong host is a stale value persisted in `/config/config.json`
from an older setup; the add-on leaves `management_url` empty and never passes
`--management-url`, so NetBird keeps the persisted value rather than its correct
built-in default (`api.netbird.io`). NetBird's own `UpdateOldManagementURL`
migration only rewrites `api.netbird.io`/`api.wiretrustee.com` hosts, so an
`app.netbird.io` value is never auto-corrected.

Fix: the service script now self-heals — when the user has set no `management_url`
and the persisted Management host is `app.netbird.io`, it passes
`--management-url https://api.netbird.io`. NetBird then rewrites and persists the
corrected URL. Self-hosted users (who set a non-empty `management_url`) are untouched,
and the rewrite is idempotent on later boots.

## Test Plan

- `bash -n` and `shellcheck` on the modified service script: clean.
- Verified the jq extraction + host-match against realistic `config.json` shapes:
  stale `app.netbird.io` with/without `:443` port -> corrected; `api.netbird.io`,
  self-hosted host, missing `ManagementURL`, and missing config file -> left untouched.
- Confirmed upstream bundled v0.74.3 default is `api.netbird.io` and `app.netbird.io`
  is only the admin/dashboard URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improves startup reliability by automatically recovering from stale NetBird Cloud Management URL settings.
  * Detects and corrects an outdated dashboard-only endpoint so the service connects to the right API URL.
  * Emits a warning when it applies the configuration correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->