### PR TITLE
fix: publish pre-built images to fix install/update failures (#397)

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -112,7 +112,7 @@ jobs:
             echo "build_arch=false" >> $GITHUB_OUTPUT;
           elif [[ "$INFO_ARCHITECTURES" =~ $BUILD_ARCH ]]; then
             echo "build_arch=true" >> $GITHUB_OUTPUT;
-            echo "image=$(echo "$INFO_IMAGE" | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
+            echo "image=$(echo "$INFO_IMAGE" | tr -d '"' | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
             if [[ -z "$HEAD_REF" ]] && [[ "$EVENT_NAME" == "push" ]]; then
                 echo "BUILD_ARGS=" >> $GITHUB_ENV;
             fi

--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -4,6 +4,7 @@ version: v0.74.3
 slug: netbird
 description: Connect your devices into a single secure private WireGuard®-based mesh network.
 url: https://github.com/netbirdio/addon-netbird
+image: ghcr.io/netbirdio/{arch}-addon-netbird
 startup: services
 panel_icon: mdi:vpn
 init: false


### PR DESCRIPTION
# Proposed Changes

Add an `image:` key to `netbird/config.yaml`:

```yaml
image: ghcr.io/netbirdio/{arch}-addon-netbird
```

**Why:** The add-on had no `image:` key, so the Home Assistant Supervisor was forced to **build the container locally** on every user's hardware. Local builds are fragile and fail on some setups with errors such as *"Dockerfile missing"* (see #397). On top of that, the CI build workflow explicitly skips building when `image` is `null`:

```
if [[ "$INFO_IMAGE" == "null" ]]; then
  echo "Image property is not defined, skipping build"
```

So no pre-built images have ever been published to GHCR, even though `builder.yaml` is fully wired to push to `ghcr.io/${{ github.repository_owner }}` with `packages: write` and a GHCR login step. (`git log -S 'image:' -- netbird/config.yaml` confirms the key never existed.)

**Effect of this change:**
- CI now builds and pushes multi-arch images on merge to `main`: `ghcr.io/netbirdio/amd64-addon-netbird` and `ghcr.io/netbirdio/aarch64-addon-netbird`, tagged with the add-on `version`.
- The Supervisor substitutes `{arch}` and `docker pull`s the pre-built image instead of building locally — fixing the reported install/update failure and making updates reliable.

The naming (`{arch}-addon-netbird`) follows the `home-assistant/builder` convention and matches this repo's existing CI, which extracts the image name via `cut -d'/' -f3` and prepends `--docker-hub ghcr.io/netbirdio`. Traced through both the build (push) and Supervisor (pull) sides — they produce identical image strings.

**Verification:** This PR's CI build (`builder.yaml`, runs with `--test` on PRs) will build both architectures for the first time and validate the previously-dormant build path end-to-end.

## Related Issues

Closes #397

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/addon-netbird/pr/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786738134&installation_id=146802194&pr_number=409&repository=netbirdio%2Faddon-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Faddon-netbird%2Fpull%2F409&signature=62d9db5bbb3f0e9c34a115652becb5475648de917282044b194e208ce1b3cc0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added architecture-specific container image selection for the NetBird add-on, using an `{arch}`-based image reference to improve compatibility across supported device architectures.
* **Bug Fixes**
  * Improved the add-on build process to correctly parse the image reference (removing extraneous quotes) before passing it to the build action, reducing the chance of incorrect image selection during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->