### PR TITLE
fix: accept empty values for optional url/hostname options

### DIFF
--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -30,10 +30,10 @@ options:
   rosenpass_permissive: false
   env_vars: []
 schema:
-  admin_url: url?
-  management_url: url?
+  admin_url: str?
+  management_url: str?
   setup_key: str?
-  hostname: match(^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$)?
+  hostname: match(^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*)?$)?
   rosenpass: bool
   rosenpass_permissive: bool
   env_vars:


### PR DESCRIPTION
# Proposed Changes

Optional options that default to an empty string (`admin_url`, `management_url`, `hostname`) were declared with schema types that **cannot accept `""`**. Home Assistant Supervisor validates the *stored* option values against the schema, and recent Supervisor releases tightened `url` validation to reject empty strings. The result: the add-on fails option validation **before the container starts**, and Home Assistant reports:

> App NetBird is set to start at boot but failed to start. Usually this occurs when the configuration is incorrect…

This happens on **both** boot and manual **Start** (validation runs first either way), and affects any install that leaves these fields blank — i.e. every NetBird *cloud* user. It was confirmed live on a HAOS 18.1 host:

```
Error: App ..._netbird has invalid options: expected a URL.
Got {'admin_url': '', 'management_url': '', ...}
```

### Fix

- `admin_url` / `management_url`: `url?` → `str?`. Blank (→ NetBird's built-in defaults, handled in `run`) and any URL both validate. Crucially, `str?` also **re-validates the `""` already stored** in existing installs, so they recover simply by updating.
- `hostname`: wrap the FQDN grammar in an optional group — `match(^(<fqdn>)?$)?` — so a blank hostname validates while a set value is still fully checked. This preserves the FQDN validation added in #407.

`run` already treats blank as "use defaults", so behaviour is unchanged for any configured value. Verified the new `hostname` regex accepts blank + valid FQDNs and still rejects malformed hostnames (leading hyphen, underscore, trailing-hyphen label).

No version bump here on purpose: the pending #410 (bump to v0.74.6) carries the version increment, and the two compose into a v0.74.6 build that ships this fix to users.

## Related Issues

> Fixes the "set to start at boot but failed to start" validation failure for blank `admin_url`/`management_url`. Related to the URL-handling work in #401 / #408.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/addon-netbird/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786793581&installation_id=146802194&pr_number=411&repository=netbirdio%2Faddon-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Faddon-netbird%2Fpull%2F411&signature=1b240a6b533ac9aca43eae70d159a7610478e94d85b50b40c3b28f52db95c68b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation for administrative and management addresses.
  * Updated hostname validation to support the intended hostname formats and optional values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->