### PR TITLE
✨ Add profile option to switch NetBird profiles

### DIFF
--- a/netbird/DOCS.md
+++ b/netbird/DOCS.md
@@ -75,6 +75,24 @@ Hostname in the NetBird network (used to during registration)
 
 This hostname will be used in the Peers to identify your machine.
 
+### Option: `profile`
+
+Name of the profile to connect with (default: the single, unnamed profile)
+
+A profile is a separate NetBird configuration: each one keeps its own peer
+identity and credentials, so switching the profile makes this client join a
+different NetBird network or account. Leave the option empty to keep using the
+single default configuration at `/addon_config/*_netbird/config.json`; set it to
+a name (letters, digits, `-` and `_`) and the client uses
+`/addon_config/*_netbird/profiles/<name>.json` instead.
+
+A profile that has not been registered yet needs a `setup_key`, or the login URL
+printed in the log, the first time it starts. Once registered, a profile keeps
+working when you switch away and back again.
+
+See [Switching profiles from Home Assistant](#switching-profiles-from-home-assistant)
+for changing profiles from an automation.
+
 ### Option: `rosenpass`
 
 Rosenpass can be enabled by setting a flag on client start-up.
@@ -96,6 +114,65 @@ Extra environment variables
 Extra environment variables to pass to the NetBird client.
 This is a list of environment variables that will be passed to the NetBird client.
 You can use this to configure the client further.
+
+## Switching profiles from Home Assistant
+
+Home Assistant can switch profiles by changing the `profile` option and
+restarting the add-on. Add the following to `configuration.yaml`, replacing
+`xxxxxxxx_netbird` with the slug of your installation (visible in the address bar
+when the add-on page is open):
+
+```yaml
+rest_command:
+  netbird_info:
+    url: http://supervisor/addons/xxxxxxxx_netbird/info
+    method: get
+    headers:
+      authorization: !env_var SUPERVISOR_TOKEN
+  netbird_set_options:
+    url: http://supervisor/addons/xxxxxxxx_netbird/options
+    method: post
+    content_type: application/json
+    headers:
+      authorization: !env_var SUPERVISOR_TOKEN
+    payload: '{{ {"options": options} | to_json }}'
+  netbird_restart:
+    url: http://supervisor/addons/xxxxxxxx_netbird/restart
+    method: post
+    headers:
+      authorization: !env_var SUPERVISOR_TOKEN
+
+script:
+  netbird_switch_profile:
+    alias: Switch NetBird profile
+    fields:
+      profile:
+        description: Profile to connect with, or empty for the default profile.
+        example: work
+    sequence:
+      - action: rest_command.netbird_info
+        response_variable: info
+      - action: rest_command.netbird_set_options
+        data:
+          options: "{{ info.content.data.options | combine({'profile': profile}) }}"
+      - action: rest_command.netbird_restart
+```
+
+Then call `script.netbird_switch_profile` with the profile you want:
+
+```yaml
+action: script.netbird_switch_profile
+data:
+  profile: work
+```
+
+Keep the `netbird_info` step. The Supervisor **replaces** the stored options with
+whatever is posted, so sending only the profile would reset every other option
+(including your `setup_key`) to its default. Reading the current options first
+and merging the new profile into them avoids that.
+
+Switching restarts the add-on, so the connection drops for a few seconds and all
+peers see the machine go offline and come back under its new identity.
 
 ## Changelog & Releases
 

--- a/netbird/DOCS.md
+++ b/netbird/DOCS.md
@@ -28,7 +28,12 @@ comparison to installing any other Home Assistant add-on.
 
 ## Configuration
 
-You'll see the config file at `/addon_config/*_netbird/config.json` after first boot.
+After the first boot you'll see the NetBird configuration in this add-on's own
+configuration directory: `/config` as seen from inside the add-on, which Home
+Assistant exposes to you as `/addon_configs/xxxxxxxx_netbird`, where
+`xxxxxxxx_netbird` is the slug of your installation (visible in the address bar
+when the add-on page is open). It holds `config.json`, plus a `profiles`
+directory if you use the [`profile`](#option-profile) option.
 
 ### Option: `log_level`
 
@@ -82,9 +87,13 @@ Name of the profile to connect with (default: the single, unnamed profile)
 A profile is a separate NetBird configuration: each one keeps its own peer
 identity and credentials, so switching the profile makes this client join a
 different NetBird network or account. Leave the option empty to keep using the
-single default configuration at `/addon_config/*_netbird/config.json`; set it to
-a name (letters, digits, `-` and `_`) and the client uses
-`/addon_config/*_netbird/profiles/<name>.json` instead.
+single default configuration at `config.json`; set it to a name and the client
+uses `profiles/<name>.json` instead. Both paths are relative to the add-on
+configuration directory described under [Configuration](#configuration).
+
+A name may be up to 64 characters of letters, digits, `-` and `_`. The name
+`null` is not allowed, because the add-on cannot tell it apart from an unset
+option.
 
 A profile that has not been registered yet needs a `setup_key`, or the login URL
 printed in the log, the first time it starts. Once registered, a profile keeps
@@ -128,19 +137,19 @@ rest_command:
     url: http://supervisor/addons/xxxxxxxx_netbird/info
     method: get
     headers:
-      authorization: !env_var SUPERVISOR_TOKEN
+      x-supervisor-token: !env_var SUPERVISOR_TOKEN
   netbird_set_options:
     url: http://supervisor/addons/xxxxxxxx_netbird/options
     method: post
     content_type: application/json
     headers:
-      authorization: !env_var SUPERVISOR_TOKEN
+      x-supervisor-token: !env_var SUPERVISOR_TOKEN
     payload: '{{ {"options": options} | to_json }}'
   netbird_restart:
     url: http://supervisor/addons/xxxxxxxx_netbird/restart
     method: post
     headers:
-      authorization: !env_var SUPERVISOR_TOKEN
+      x-supervisor-token: !env_var SUPERVISOR_TOKEN
 
 script:
   netbird_switch_profile:
@@ -152,9 +161,14 @@ script:
     sequence:
       - action: rest_command.netbird_info
         response_variable: info
+      - condition: template
+        value_template: "{{ info.status == 200 }}"
       - action: rest_command.netbird_set_options
+        response_variable: updated
         data:
           options: "{{ info.content.data.options | combine({'profile': profile}) }}"
+      - condition: template
+        value_template: "{{ updated.status == 200 }}"
       - action: rest_command.netbird_restart
 ```
 
@@ -170,6 +184,18 @@ Keep the `netbird_info` step. The Supervisor **replaces** the stored options wit
 whatever is posted, so sending only the profile would reset every other option
 (including your `setup_key`) to its default. Reading the current options first
 and merging the new profile into them avoids that.
+
+Keep the two `condition` steps as well. A `rest_command` that gets an error
+response logs a warning but does not fail the script, so without them a rejected
+options update would still be followed by a restart, quietly bringing the add-on
+back up on the *old* profile. With them, the script stops instead and the add-on
+keeps running untouched.
+
+Because the whole options map has to be posted back, the payload contains your
+`setup_key`. Home Assistant logs that payload at warning level whenever one of
+these calls fails, and logs the payload and headers (including the Supervisor
+token) if you set `homeassistant.components.rest_command` to `debug`. Treat
+those logs as secrets, and scrub them before sharing them.
 
 Switching restarts the add-on, so the connection drops for a few seconds and all
 peers see the machine go offline and come back under its new identity.

--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -27,6 +27,7 @@ options:
   management_url: ""
   setup_key: ""
   hostname: ""
+  profile: ""
   rosenpass: false
   rosenpass_permissive: false
   env_vars: []
@@ -35,6 +36,7 @@ schema:
   management_url: str?
   setup_key: str?
   hostname: match(^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*)?$)?
+  profile: match(^([a-zA-Z0-9_-]{1,64})?$)?
   rosenpass: bool
   rosenpass_permissive: bool
   env_vars:

--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -36,7 +36,7 @@ schema:
   management_url: str?
   setup_key: str?
   hostname: match(^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*)?$)?
-  profile: match(^([a-zA-Z0-9_-]{1,64})?$)?
+  profile: match(^(?!null$)([a-zA-Z0-9_-]{1,64})?$)?
   rosenpass: bool
   rosenpass_permissive: bool
   env_vars:

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -11,17 +11,40 @@ declare value
 
 # Get the options configured in HASS GUI
 readonly CONFIG_OLD_PATH=/homeassistant/netbird/config.json
-readonly CONFIG_PATH=/config/config.json
+readonly CONFIG_DEFAULT_PATH=/config/config.json
+readonly PROFILES_DIR=/config/profiles
 
-[ -f "${CONFIG_OLD_PATH}" ] && mv "${CONFIG_OLD_PATH}" "${CONFIG_PATH}"
+[ -f "${CONFIG_OLD_PATH}" ] && mv "${CONFIG_OLD_PATH}" "${CONFIG_DEFAULT_PATH}"
 
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"
 setup_key="$(bashio::config 'setup_key')"
 hostname="$(bashio::config 'hostname')"
+profile="$(bashio::config 'profile')"
 rosenpass="$(bashio::config 'rosenpass')"
 rosenpass_permissive="$(bashio::config 'rosenpass_permissive')"
 log_level="$(bashio::config 'log_level')"
+
+# Select the profile to run (see issue #423).
+# A NetBird profile is simply its own config file: each one holds a separate
+# peer identity, management URL and credentials, so pointing the client at a
+# different config file switches the whole account/network it joins. Leaving
+# the option empty keeps using the single default config, so existing installs
+# are unaffected.
+if [ "${profile}" = "" ] || [ "${profile}" = "null" ]; then
+    bashio::log.info "No profile set, using the default profile"
+    CONFIG_PATH="${CONFIG_DEFAULT_PATH}"
+else
+    # The profile name becomes part of a file path, so re-validate it here
+    # instead of relying on the options schema alone.
+    if [[ ! "${profile}" =~ ^[a-zA-Z0-9_-]{1,64}$ ]]; then
+        bashio::exit.nok "Invalid profile name: ${profile} (allowed: letters, digits, '-' and '_', up to 64 characters)"
+    fi
+    bashio::log.info "Using ${profile} as profile"
+    mkdir -p "${PROFILES_DIR}"
+    CONFIG_PATH="${PROFILES_DIR}/${profile}.json"
+fi
+readonly CONFIG_PATH
 
 # Self-heal a stale NetBird Cloud management URL (see issue #401).
 # Older installs persisted https://app.netbird.io as the Management URL in

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -14,7 +14,15 @@ readonly CONFIG_OLD_PATH=/homeassistant/netbird/config.json
 readonly CONFIG_DEFAULT_PATH=/config/config.json
 readonly PROFILES_DIR=/config/profiles
 
-[ -f "${CONFIG_OLD_PATH}" ] && mv "${CONFIG_OLD_PATH}" "${CONFIG_DEFAULT_PATH}"
+# Migrate the config from the pre-addon_config location, but never on top of an
+# existing one: that would discard the current peer identity and credentials.
+if [ -f "${CONFIG_OLD_PATH}" ]; then
+    if [ -f "${CONFIG_DEFAULT_PATH}" ]; then
+        bashio::log.warning "Ignoring ${CONFIG_OLD_PATH}: ${CONFIG_DEFAULT_PATH} already exists"
+    elif ! mv "${CONFIG_OLD_PATH}" "${CONFIG_DEFAULT_PATH}"; then
+        bashio::exit.nok "Could not migrate ${CONFIG_OLD_PATH} to ${CONFIG_DEFAULT_PATH}"
+    fi
+fi
 
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -31,6 +31,9 @@ log_level="$(bashio::config 'log_level')"
 # different config file switches the whole account/network it joins. Leaving
 # the option empty keeps using the single default config, so existing installs
 # are unaffected.
+# bashio prints "null" for an option that is not set, and cannot tell that
+# apart from the literal string; the schema rejects "null" as a profile name so
+# the two can never collide here.
 if [ "${profile}" = "" ] || [ "${profile}" = "null" ]; then
     bashio::log.info "No profile set, using the default profile"
     CONFIG_PATH="${CONFIG_DEFAULT_PATH}"

--- a/netbird/translations/en.yaml
+++ b/netbird/translations/en.yaml
@@ -29,6 +29,17 @@ configuration:
     description: >-
       Hostname of the client (default "netbird-client")
       This is the name of the client that will be displayed in the NetBird dashboard.
+  profile:
+    name: Profile
+    description: >-
+      Name of the profile to connect with (default: the single, unnamed profile)
+
+      Every profile keeps its own peer identity and credentials in its own
+      configuration file, so switching the profile makes the add-on join a
+      different NetBird network or account. Changing this option and restarting
+      the add-on switches profiles, which also lets Home Assistant automations
+      switch networks. A profile that has not been registered yet needs a
+      `setup_key`, or the login URL printed in the log, on its first start.
   rosenpass:
     name: Rosenpass
     description: >-

--- a/netbird/translations/en.yaml
+++ b/netbird/translations/en.yaml
@@ -40,6 +40,9 @@ configuration:
       the add-on switches profiles, which also lets Home Assistant automations
       switch networks. A profile that has not been registered yet needs a
       `setup_key`, or the login URL printed in the log, on its first start.
+
+      Up to 64 characters of letters, digits, `-` and `_`. The name `null` is
+      not allowed, as it cannot be told apart from an unset option.
   rosenpass:
     name: Rosenpass
     description: >-


### PR DESCRIPTION
Closes #423.

## What

Adds a `profile` add-on option. A NetBird profile is simply its own config file — each one holds a separate peer identity, management URL and credentials — so pointing the client at a different config file switches the whole account/network it joins.

- empty (default) → `/config/config.json`, exactly today's behaviour
- `work` → `/config/profiles/work.json`

Home Assistant switches networks by changing the option and restarting the add-on. `DOCS.md` gains a *Switching profiles from Home Assistant* section with the `rest_command`s and script to do that from an automation.

## Why not `netbird profile ...`

The upstream profile commands (and `netbird up --profile`) all dial the daemon over gRPC — `client/cmd/up.go` calls `switchOrCreateProfile` *before* branching into foreground mode. This add-on runs `netbird up --foreground-mode`, which never starts that socket, so the native commands are unusable without reworking the add-on into daemon mode. Selecting the config file achieves the same result with 25 lines of shell.

## Notes for review

- **Schema:** `match(^([a-zA-Z0-9_-]{1,64})?$)?` — the grammar is wrapped in an optional group so the stored `""` default still validates. This is the same shape `hostname` uses after #411; a bare `match(^[a-zA-Z0-9_-]+$)?` would re-break start-at-boot on every install storing the default.
- **Double validation:** the run script re-checks the name against the same grammar because that string becomes a filesystem path. This blocks traversal independently of the schema, mirroring what the `env_vars` loop already does.
- **Legacy migration:** the `/homeassistant/netbird/config.json` → `/config/config.json` move still targets the *default* path and runs before profile selection, so an upgrading user's old credentials cannot land in a profile file.
- **Docs caveat:** Supervisor's options endpoint *replaces* persisted options, so the documented automation reads `/info` and merges before posting. A partial payload would silently reset `setup_key` and friends to their defaults.
- **No version bump:** `config.yaml` `version:` tracks the NetBird release and must match the Dockerfile tag, so this rides the next Renovate bump.

## Verification

`shellcheck` and `bash -n` clean; both YAMLs parse; every schema key has a translation.

Two test harnesses were run locally (not committed — this repo has no test suite):

1. The real run script, with only its absolute paths redirected into a temp dir and bashio/netbird stubbed, asserting the resulting `--config` value. 10/10 pass: unset → default config, `null` → default config, named profile → profiles dir, and `../evil`, `a/b`, `/etc/shadow`, `a b`, 65 chars all abort without invoking netbird. Includes a case asserting the legacy migration still lands in the default config when a profile is set.
2. The schema entry checked with `RE_SCHEMA_ELEMENT` lifted verbatim from Supervisor's `apps/options.py` plus `vol.Match` semantics. 11/11 pass, confirming `""` is accepted and `../evil`, `a/b`, `a.json`, non-ASCII are rejected.

Not verified locally: `yamllint` and the add-on linter (no container registry access from my environment) — CI is the first real check. No live HAOS test, since that needs a built test image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for separate NetBird profiles with independent peer identities and credentials.
  - Profile names support letters, numbers, hyphens, and underscores, up to 64 characters.
  - Profiles can be switched after restarting the add-on to connect to different networks.
  - Unregistered profiles support first-time setup with a setup key or login URL.
  - Existing installations continue using the default profile when none is selected.

- **Documentation**
  - Added configuration guidance and Home Assistant automation instructions.
  - Documented temporary disconnection during switching and profile option reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->