### PR TITLE
Add support for preshared key configuration and redact logging output

### DIFF
--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -26,6 +26,7 @@ options:
   admin_url: ""
   management_url: ""
   setup_key: ""
+  preshared_key: ""
   hostname: ""
   rosenpass: false
   rosenpass_permissive: false
@@ -34,6 +35,7 @@ schema:
   admin_url: str?
   management_url: str?
   setup_key: str?
+  preshared_key: str?
   hostname: match(^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*)?$)?
   rosenpass: bool
   rosenpass_permissive: bool

--- a/netbird/config.yaml
+++ b/netbird/config.yaml
@@ -35,7 +35,7 @@ schema:
   admin_url: str?
   management_url: str?
   setup_key: str?
-  preshared_key: str?
+  preshared_key: password?
   hostname: match(^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*)?$)?
   rosenpass: bool
   rosenpass_permissive: bool

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -70,6 +70,7 @@ fi
 
 if [ "${preshared_key}" = "" ]; then
     bashio::log.info "No Preshared Key Set"
+    options+=(--preshared-key "")
 else
     bashio::log.info "Preshared Key configured (hidden for security)"
     options+=(--preshared-key "${preshared_key}")
@@ -132,7 +133,11 @@ log_options=()
 redact_next=false
 for opt in "${options[@]}"; do
     if ${redact_next}; then
-        log_options+=("<redacted>")
+        if [ "${opt}" = "" ]; then
+            log_options+=("\"\"")
+        else
+            log_options+=("<redacted>")
+        fi
         redact_next=false
         continue
     fi

--- a/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
+++ b/netbird/rootfs/etc/s6-overlay/s6-rc.d/netbird/run
@@ -5,6 +5,7 @@
 # Runs NetBird Client
 # ==============================================================================
 declare -a options
+declare -a log_options
 declare name
 declare value
 
@@ -18,6 +19,7 @@ readonly CONFIG_PATH=/config/config.json
 admin_url="$(bashio::config 'admin_url')"
 management_url="$(bashio::config 'management_url')"
 setup_key="$(bashio::config 'setup_key')"
+preshared_key="$(bashio::config 'preshared_key')"
 hostname="$(bashio::config 'hostname')"
 rosenpass="$(bashio::config 'rosenpass')"
 rosenpass_permissive="$(bashio::config 'rosenpass_permissive')"
@@ -64,6 +66,13 @@ if [ "${setup_key}" = "" ]; then
 else
     bashio::log.info "Setup Key configured (hidden for security)"
     options+=(--setup-key "${setup_key}")
+fi
+
+if [ "${preshared_key}" = "" ]; then
+    bashio::log.info "No Preshared Key Set"
+else
+    bashio::log.info "Preshared Key configured (hidden for security)"
+    options+=(--preshared-key "${preshared_key}")
 fi
 
 if [ "${hostname}" = "" ]; then
@@ -117,5 +126,27 @@ echo '# systemd-resolved' > /etc/resolv.conf
 echo "$CONTENT" >> /etc/resolv.conf
 
 bashio::log.info "Starting NetBird Client..."
-bashio::log.info "netbird up " "${options[@]}"
+
+# Log a redacted command line to avoid leaking secret key material.
+log_options=()
+redact_next=false
+for opt in "${options[@]}"; do
+    if ${redact_next}; then
+        log_options+=("<redacted>")
+        redact_next=false
+        continue
+    fi
+
+    case "${opt}" in
+        --setup-key|--preshared-key)
+            log_options+=("${opt}")
+            redact_next=true
+            ;;
+        *)
+            log_options+=("${opt}")
+            ;;
+    esac
+done
+
+bashio::log.info "netbird up " "${log_options[@]}"
 netbird up "${options[@]}"

--- a/netbird/translations/en.yaml
+++ b/netbird/translations/en.yaml
@@ -27,8 +27,8 @@ configuration:
   preshared_key:
     name: Preshared Key
     description: >-
-      Sets WireGuard PreSharedKey property.
-      If set, then only peers that have the same key can communicate.
+       Sets a WireGuard pre-shared key (PSK).
+       Only peers with the same key can communicate.
   hostname:
     name: Hostname
     description: >-

--- a/netbird/translations/en.yaml
+++ b/netbird/translations/en.yaml
@@ -24,6 +24,11 @@ configuration:
       This token is like a password for connecting your client to NetBird, you can
       leave this option empty if you would prefer to login via a URL generated in
       the log with the `admin_url`.
+  preshared_key:
+    name: Preshared Key
+    description: >-
+      Sets WireGuard PreSharedKey property.
+      If set, then only peers that have the same key can communicate.
   hostname:
     name: Hostname
     description: >-


### PR DESCRIPTION
# Proposed Changes

Added optional NetBird preshared key support in the Home Assistant addon configuration.
The key is passed to netbird up, and sensitive values are redacted from startup logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an optional WireGuard pre-shared key.
  * The key can restrict peer communication to connections using the same key.
  * Added configuration guidance, password validation, and an empty default value for the option.

* **Security**
  * Sensitive setup-key and pre-shared-key values are now hidden in command-line logs while commands continue to run normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->